### PR TITLE
README: Remove deprecated --no-quarantine flag from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the [Homebrew](https://brew.sh) cask for Boring Notch
 This app can be installed using Homebrew by running the following command:
 
 ```
-brew install --cask TheBoredTeam/boring-notch/boring-notch --no-quarantine
+brew install --cask TheBoredTeam/boring-notch/boring-notch
 ```
 
 The app includes an internal updater, but you can also manually update it through Homebrew by running: 


### PR DESCRIPTION
## Summary
- Removes the deprecated `--no-quarantine` flag from the Homebrew install command
- The flag has been deprecated by Homebrew with no replacement and will be fully removed in a future version

Closes #4

## Reference
Same fix applied in the main repo: TheBoredTeam/boring.notch#1108